### PR TITLE
修复手机上顶栏的显示

### DIFF
--- a/_sass/layout/_header.scss
+++ b/_sass/layout/_header.scss
@@ -26,6 +26,12 @@
 
     img {
       max-height: 60px;
+      &:first-child {
+        max-width: calc((100vw - 104px) * 106 / 407);
+      }
+      &:last-child {
+        max-width: calc((100vw - 104px) * 300 / 407);
+      }
     }
   }
 


### PR DESCRIPTION
当屏幕宽度较窄时，缩小图片：

![Screen Shot 2023-04-19 at 15 32 12](https://user-images.githubusercontent.com/34163622/233003856-726181ab-470f-446b-8d14-3d600a4a5f1c.png)