### PR TITLE
修复DPS数据表无法正常显示的问题

### DIFF
--- a/_docs/character_ranking.js
+++ b/_docs/character_ranking.js
@@ -19,6 +19,7 @@ function init() {
     'excel/gamedata_const.json',
     '../version.json',
     '../customdata/dps_specialtags.json',
+    '../customdata/enums.json',
     '../customdata/dps_options.json',
     '../customdata/dps_anim.json',
     '../resources/attributes.js'


### PR DESCRIPTION
应该就是少load了一个enums.json，加上就显示正常了。

现在的样子：
![image](https://github.com/xulai1001/akdata/assets/64887296/08869c5d-a6b6-4ee9-93b9-e0ce38536f18)

修复后的样子：
![image](https://github.com/xulai1001/akdata/assets/64887296/df1fdfbc-587e-45bb-9e00-08bc9be9c989)

